### PR TITLE
Add new() to PageTableEntry and PageTable

### DIFF
--- a/src/paging/page_table.rs
+++ b/src/paging/page_table.rs
@@ -30,13 +30,19 @@ pub enum FrameError {
 }
 
 /// A 64-bit page table entry.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct PageTableEntry {
     entry: u64,
 }
 
 impl PageTableEntry {
+    /// Creates an unused entry.
+    #[inline]
+    pub const fn new() -> Self {
+        Self { entry: 0 }
+    }
+
     /// Returns whether this entry is zero.
     #[inline]
     pub fn is_unused(&self) -> bool {
@@ -244,6 +250,13 @@ pub struct PageTable {
 }
 
 impl PageTable {
+    /// Creates an empty page table.
+    pub const fn new() -> Self {
+        Self {
+            entries: [PageTableEntry::new(); ENTRY_COUNT],
+        }
+    }
+
     /// Clears all entries.
     pub fn zero(&mut self) {
         for entry in self.entries.iter_mut() {


### PR DESCRIPTION
Add `PageTable::new()` so you can easily create boot page tables as static variables in Rust:

```rust
#[link_section = ".bss"]
static mut BOOT_PGD: PageTable = PageTable::new();

#[link_section = ".text.boot"]
pub fn create_boot_pt() {
    let pgd = unsafe { &mut BOOT_PGD };
    pgd[0].set_frame(...);
}
```

instead of using asm and extern:

```rust
global_asm!(
    "
    .section .bss
    .align 12
boot_pgd:
    .space 0x1000
    "
);

extern "C" {
    fn boot_pgd();
}

#[link_section = ".text.boot"]
pub fn create_boot_pt() {
    let pgd = unsafe { &mut *(boot_pgd as *mut PageTable) };
    pgd[0].set_frame(...);
}
```